### PR TITLE
Add issue template forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -18,7 +18,6 @@ body:
         description: |
             Specify the category of the bug you are reporting.
         options:
-            - Compilation warning
             - Compilation error
             - Runtime crash
             - Visual artefact
@@ -50,8 +49,8 @@ body:
       attributes:
         label: The reproduction
         description: |
-            Steps to reproduce the behaviour as you have mentioned. Usually you should provide a small and self-contained piece of code that uses SuperTerrain+ and specify any relevant configuration and compiler flags, as applicable.
-        placeholder: |
+            Describe procedures to reproduce the behaviour as you have mentioned. Usually you should provide a small and self-contained piece of code that uses SuperTerrain+ and specify any relevant configuration and compiler flag, if applicable.
+        value: |
             1. Go to ...
             2. Set the setting ... to value ...
             3. Use these code ...

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -8,7 +8,7 @@ body:
         description: |
             Thanks for taking the time to fill out this bug report! To avoid opening a duplicate issue, please search the issue tracker to see if there is an existing issue for the problem you are experiencing.
         options:
-            - label: I could not find a similar issue and confirm this is a new issue.
+            - label: I could not find a similar issue and confirm this is a new bug.
               required: true
         
     - type: dropdown
@@ -33,7 +33,6 @@ body:
         label: The problem
         description: |
             Describe the issue you are experiencing with SuperTerrain+. Provide a clear and concise description of what you were trying to do and what happened, along with any error message you encountered or screenshot, if applicable.
-        render: markdown
       validations:
         required: true
     
@@ -42,8 +41,7 @@ body:
       attributes:
         label: The expectation
         description: |
-            Provide a clear and concise description of what you are expecting the program to behave if you have performed the actions specified above.
-        render: markdown
+            Provide a clear and concise description of what you are expecting the program to behave.
       validations:
         required: true
     
@@ -59,7 +57,6 @@ body:
             3. Use these code ...
             4. Run the application
             5. See error as ...
-        render: markdown
       validations:
         required: true
     
@@ -68,7 +65,9 @@ body:
       attributes:
         label: The release
         description: |
-            Specify the release version of SuperTerrain+ you had problem with. If you are not using a release, please specify the commit hash.
+            Specify the release version of SuperTerrain+ you had problem with. If you are not using a release, please specify the full commit hash.
+        placeholder: |
+            e.g. 0.1.2 or 2a44ebe0fdd545496f35502ee26235c464c57c6a
       validations:
         required: true
         
@@ -78,6 +77,8 @@ body:
         label: The operating system
         description: |
             Provide the operating system and version you are using.
+        placeholder: |
+            e.g. Windows 10 21H2
       validations:
         required: true
         
@@ -92,7 +93,6 @@ body:
             **Graphics driver**:
             **CUDA version**:
             **Compiler and version**:
-        render: markdown
       validations:
         required: true
         
@@ -102,7 +102,6 @@ body:
         label: The additional
         description: |
             Add any other context about the problem you are experiencing here; for example, if you have any idea why this bug was happening.
-        render: markdown
         
     - type: checkboxes
       id: the-contribution

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -107,7 +107,7 @@ body:
     - type: checkboxes
       id: the-contribution
       attributes:
-        label: The Contribution
+        label: The contribution
         description: |
             Would you like to make a contribution to fix this issue?
         options:

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -5,7 +5,7 @@ body:
       id: the-issue
       attributes:
         label: The issue
-        description:
+        description: |
             Thanks for taking the time to fill out this bug report! To avoid opening a duplicate issue, please search the issue tracker to see if there is an existing issue for the problem you are experiencing.
         options:
             - label: I could not find a similar issue and confirm this is a new issue.
@@ -15,7 +15,7 @@ body:
       id: the-category
       attributes:
         label: The category
-        description:
+        description: |
             Specify the category of the bug you are reporting.
         options:
             - Compilation warning
@@ -31,7 +31,7 @@ body:
       id: the-problem
       attributes:
         label: The problem
-        description:
+        description: |
             Describe the issue you are experiencing with SuperTerrain+. Provide a clear and concise description of what you were trying to do and what happened, along with any error message you encountered or screenshot, if applicable.
         render: markdown
       validations:
@@ -41,7 +41,7 @@ body:
       id: the-expectation
       attributes:
         label: The expectation
-        description:
+        description: |
             Provide a clear and concise description of what you are expecting the program to behave if you have performed the actions specified above.
         render: markdown
       validations:
@@ -51,14 +51,14 @@ body:
       id: the-reproduction
       attributes:
         label: The reproduction
-        description:
+        description: |
             Steps to reproduce the behaviour as you have mentioned. Usually you should provide a small and self-contained piece of code that uses SuperTerrain+ and specify any relevant configuration and compiler flags, as applicable.
         placeholder: |
             1. Go to ...
-            1. Set the setting ... to value ...
-            1. Use these code ...
-            1. Run the application
-            1. See error as ...
+            2. Set the setting ... to value ...
+            3. Use these code ...
+            4. Run the application
+            5. See error as ...
         render: markdown
       validations:
         required: true
@@ -67,7 +67,7 @@ body:
       id: the-release
       attributes:
         label: The release
-        description:
+        description: |
             Specify the release version of SuperTerrain+ you had problem with. If you are not using a release, please specify the commit hash.
       validations:
         required: true
@@ -76,7 +76,7 @@ body:
       id: the-operating-system
       attributes:
         label: The operating system
-        description:
+        description: |
             Provide the operating system and version you are using.
       validations:
         required: true
@@ -85,10 +85,10 @@ body:
       id: the-platform
       attributes:
         label: The platform
-        description:
+        description: |
             Provide information of the platform where you work and the bug can be reproduced.
         value: |
-            **GPU**:
+            **GPU model**:
             **Graphics driver**:
             **CUDA version**:
             **Compiler and version**:
@@ -100,7 +100,7 @@ body:
       id: the-additional
       attributes:
         label: The additional
-        description:
+        description: |
             Add any other context about the problem you are experiencing here; for example, if you have any idea why this bug was happening.
         render: markdown
         
@@ -108,7 +108,7 @@ body:
       id: the-contribution
       attributes:
         label: The Contribution
-        description:
+        description: |
             Would you like to make a contribution to fix this issue?
         options:
             - label: I would like to be assigned to resolve to this issue.

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,114 @@
+name: 🐛 Bug Report
+description: I have discovered a unintended behaviour in the program
+body:
+    - type: checkboxes
+      id: the-issue
+      attributes:
+        label: The issue
+        description:
+            Thanks for taking the time to fill out this bug report! To avoid opening a duplicate issue, please search the issue tracker to see if there is an existing issue for the problem you are experiencing.
+        options:
+            - label: I could not find a similar issue and confirm this is a new issue.
+              required: true
+        
+    - type: dropdown
+      id: the-category
+      attributes:
+        label: The category
+        description:
+            Specify the category of the bug you are reporting.
+        options:
+            - Compilation warning
+            - Compilation error
+            - Runtime crash
+            - Visual artefact
+            - Performance
+            - Others
+      validations:
+        required: true
+    
+    - type: textarea
+      id: the-problem
+      attributes:
+        label: The problem
+        description:
+            Describe the issue you are experiencing with SuperTerrain+. Provide a clear and concise description of what you were trying to do and what happened, along with any error message you encountered or screenshot, if applicable.
+        render: markdown
+      validations:
+        required: true
+    
+    - type: textarea
+      id: the-expectation
+      attributes:
+        label: The expectation
+        description:
+            Provide a clear and concise description of what you are expecting the program to behave if you have performed the actions specified above.
+        render: markdown
+      validations:
+        required: true
+    
+    - type: textarea
+      id: the-reproduction
+      attributes:
+        label: The reproduction
+        description:
+            Steps to reproduce the behaviour as you have mentioned. Usually you should provide a small and self-contained piece of code that uses SuperTerrain+ and specify any relevant configuration and compiler flags, as applicable.
+        placeholder: |
+            1. Go to ...
+            1. Set the setting ... to value ...
+            1. Use these code ...
+            1. Run the application
+            1. See error as ...
+        render: markdown
+      validations:
+        required: true
+    
+    - type: input
+      id: the-release
+      attributes:
+        label: The release
+        description:
+            Specify the release version of SuperTerrain+ you had problem with. If you are not using a release, please specify the commit hash.
+      validations:
+        required: true
+        
+    - type: input
+      id: the-operating-system
+      attributes:
+        label: The operating system
+        description:
+            Provide the operating system and version you are using.
+      validations:
+        required: true
+        
+    - type: textarea
+      id: the-platform
+      attributes:
+        label: The platform
+        description:
+            Provide information of the platform where you work and the bug can be reproduced.
+        value: |
+            **GPU**:
+            **Graphics driver**:
+            **CUDA version**:
+            **Compiler and version**:
+        render: markdown
+      validations:
+        required: true
+        
+    - type: textarea
+      id: the-additional
+      attributes:
+        label: The additional
+        description:
+            Add any other context about the problem you are experiencing here; for example, if you have any idea why this bug was happening.
+        render: markdown
+        
+    - type: checkboxes
+      id: the-contribution
+      attributes:
+        label: The Contribution
+        description:
+            Would you like to make a contribution to fix this issue?
+        options:
+            - label: I would like to be assigned to resolve to this issue.

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -89,7 +89,7 @@ body:
             Provide information of the platform where you work and the bug can be reproduced.
         value: |
             **GPU model**:
-            **Graphics driver**:
+            **Graphics driver version**:
             **CUDA version**:
             **Compiler and version**:
       validations:

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -18,7 +18,7 @@ body:
         description: |
             Provide a clear and concise description of the limitation in the current version of SuperTerrain+.
         render: markdown
-      validation:
+      validations:
         required: true
         
     - type: textarea
@@ -28,7 +28,7 @@ body:
         description: |
             Write a clear and concise description of the requesting feature, and demonstrate how this feature will resolve the identified limitation.
         render: markdown
-      validation:
+      validations:
         required: true
         
     - type: textarea

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,0 +1,40 @@
+name: 🌟 Feature Request
+description: I have a new idea.
+body:
+    - type: checkboxes
+      id: the-issue
+      attributes:
+        label: The issue
+        description: |
+            Thanks for taking the time to fill out this feature request! To avoid opening a duplicate issue, please search the issue tracker to see if there is an existing issue for the feature you are requesting.
+        options:
+            - label: I could not find a similar issue and confirm this is a new feature.
+              required: true
+              
+    - type: textarea
+      id: the-limitation
+      attributes:
+        label: The limitation
+        description: |
+            Provide a clear and concise description of the limitation in the current version of SuperTerrain+.
+        render: markdown
+      validation:
+        required: true
+        
+    - type: textarea
+      id: the-feature
+      attributes:
+        label: The solution
+        description: |
+            Write a clear and concise description of the requesting feature, and demonstrate how this feature will resolve the identified limitation.
+        render: markdown
+      validation:
+        required: true
+        
+    - type: textarea
+      id: the-additional
+      attributes:
+        label: The additional
+        description: |
+            Add any other context about the feature you are requesting here; for example, if you have any suggestion how this feature should be implemented.
+        render: markdown

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -17,7 +17,6 @@ body:
         label: The limitation
         description: |
             Provide a clear and concise description of the limitation in the current version of SuperTerrain+.
-        render: markdown
       validations:
         required: true
         
@@ -27,7 +26,6 @@ body:
         label: The solution
         description: |
             Write a clear and concise description of the requesting feature, and demonstrate how this feature will resolve the identified limitation.
-        render: markdown
       validations:
         required: true
         
@@ -36,5 +34,4 @@ body:
       attributes:
         label: The additional
         description: |
-            Add any other context about the feature you are requesting here; for example, if you have any suggestion how this feature should be implemented.
-        render: markdown
+            Add any other context about the feature you are requesting here; for example, if you have any suggestion how this feature could be implemented.

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,5 +1,5 @@
 name: 🌟 Feature Request
-description: I have a new idea.
+description: I have a new idea
 body:
     - type: checkboxes
       id: the-issue


### PR DESCRIPTION
2 issue templates are added in this PR:

- bug_report.yaml
- feature_request.yaml

Issue templates are formatted using the new GitHub forms feature because it seems to be pretty nice :+1: